### PR TITLE
WIP/PoC: Implement API call for housekeeping

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -116,6 +116,8 @@ type BlobDeleter interface {
 // BlobEnumerator enables iterating over blobs from storage
 type BlobEnumerator interface {
 	Enumerate(ctx context.Context, ingester func(dgst digest.Digest) error) error
+
+	IsScopped() bool
 }
 
 // BlobDescriptorService manages metadata about a blob by digest. Most

--- a/manifests.go
+++ b/manifests.go
@@ -61,6 +61,8 @@ type ManifestService interface {
 	// Delete removes the manifest specified by the given digest. Deleting
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error
+
+	Enumerate(ctx context.Context, ingester func(digest.Digest) error) error
 }
 
 // ManifestEnumerator enables iterating over manifests

--- a/registry.go
+++ b/registry.go
@@ -105,6 +105,8 @@ type Repository interface {
 	// Blobs returns a reference to this repository's blob service.
 	Blobs(ctx context.Context) BlobStore
 
+	RepositoryBlobsEnumerator(ctx context.Context) BlobEnumerator
+
 	// TODO(stevvooe): The above BlobStore return can probably be relaxed to
 	// be a BlobService for use with clients. This will allow such
 	// implementations to avoid implementing ServeBlob.

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -502,10 +502,10 @@ var routeDescriptors = []RouteDescriptor{
 	},
 
 	{
-		Name:        RouteNameRecycle,
-		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/recycle",
-		Entity:      "Recycle",
-		Description: "Recycle the repository.",
+		Name:        RouteNameHousekeeping,
+		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/housekeeping",
+		Entity:      "Housekeeping",
+		Description: "Perform housekeeping operations.",
 		Methods: []MethodDescriptor{
 			{
 				Method:      "DELETE",

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -500,6 +500,77 @@ var routeDescriptors = []RouteDescriptor{
 			},
 		},
 	},
+
+	{
+		Name:        RouteNameRecycle,
+		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/recycle",
+		Entity:      "Recycle",
+		Description: "Recycle the repository.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "DELETE",
+				Description: "Remove all unreferenced manifests and tags.",
+				Requests: []RequestDescriptor{
+					{
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
+						PathParameters: []ParameterDescriptor{
+							nameParameterDescriptor,
+							referenceParameterDescriptor,
+						},
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode: http.StatusAccepted,
+							},
+						},
+						Failures: []ResponseDescriptor{
+							{
+								Name:        "Invalid Name or Reference",
+								Description: "The specified `name` or `reference` were invalid and the delete was unable to proceed.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []errcode.ErrorCode{
+									ErrorCodeNameInvalid,
+									ErrorCodeTagInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
+							tooManyRequestsDescriptor,
+							{
+								Name:        "Unknown Manifest",
+								Description: "The specified `name` or `reference` are unknown to the registry and the delete was unable to proceed. Clients can assume the manifest was already deleted if this response is returned.",
+								StatusCode:  http.StatusNotFound,
+								ErrorCodes: []errcode.ErrorCode{
+									ErrorCodeNameUnknown,
+									ErrorCodeManifestUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							{
+								Name:        "Not allowed",
+								Description: "Manifest delete is not allowed because the registry is configured as a pull-through cache or `delete` has been disabled.",
+								StatusCode:  http.StatusMethodNotAllowed,
+								ErrorCodes: []errcode.ErrorCode{
+									errcode.ErrorCodeUnsupported,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
 	{
 		Name:        RouteNameManifest,
 		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/manifests/{reference:" + reference.TagRegexp.String() + "|" + digest.DigestRegexp.String() + "}",

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -11,6 +11,7 @@ const (
 	RouteNameBlob            = "blob"
 	RouteNameBlobUpload      = "blob-upload"
 	RouteNameBlobUploadChunk = "blob-upload-chunk"
+	RouteNameRecycle         = "recycle"
 	RouteNameCatalog         = "catalog"
 )
 

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -11,7 +11,7 @@ const (
 	RouteNameBlob            = "blob"
 	RouteNameBlobUpload      = "blob-upload"
 	RouteNameBlobUploadChunk = "blob-upload-chunk"
-	RouteNameRecycle         = "recycle"
+	RouteNameHousekeeping    = "housekeeping"
 	RouteNameCatalog         = "catalog"
 )
 

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -174,6 +174,10 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 	}
 }
 
+func (r *repository) RepositoryBlobsEnumerator(ctx context.Context) distribution.BlobEnumerator {
+	return nil
+}
+
 func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
 	// todo(richardscothern): options should be sent over the wire
 	return &manifests{
@@ -364,6 +368,10 @@ type manifests struct {
 	ub     *v2.URLBuilder
 	client *http.Client
 	etags  map[string]string
+}
+
+func (ms *manifests) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	return nil
 }
 
 func (ms *manifests) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -109,7 +109,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	app.register(v2.RouteNameBlob, blobDispatcher)
 	app.register(v2.RouteNameBlobUpload, blobUploadDispatcher)
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)
-	app.register(v2.RouteNameRecycle, recycleDispatcher)
+	app.register(v2.RouteNameHousekeeping, recycleDispatcher)
 
 	// override the storage driver's UA string for registry outbound HTTP requests
 	storageParams := config.Storage.Parameters()

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -109,7 +109,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	app.register(v2.RouteNameBlob, blobDispatcher)
 	app.register(v2.RouteNameBlobUpload, blobUploadDispatcher)
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)
-	app.register(v2.RouteNameHousekeeping, recycleDispatcher)
+	app.register(v2.RouteNameHousekeeping, housekeepingDispatcher)
 
 	// override the storage driver's UA string for registry outbound HTTP requests
 	storageParams := config.Storage.Parameters()

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -109,6 +109,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	app.register(v2.RouteNameBlob, blobDispatcher)
 	app.register(v2.RouteNameBlobUpload, blobUploadDispatcher)
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)
+	app.register(v2.RouteNameRecycle, recycleDispatcher)
 
 	// override the storage driver's UA string for registry outbound HTTP requests
 	storageParams := config.Storage.Parameters()

--- a/registry/handlers/housekeeping.go
+++ b/registry/handlers/housekeeping.go
@@ -9,22 +9,22 @@ import (
 )
 
 // blobDispatcher uses the request context to build a blobHandler.
-func recycleDispatcher(ctx *Context, r *http.Request) http.Handler {
-	recycleHandler := &recycleHandler{
+func housekeepingDispatcher(ctx *Context, r *http.Request) http.Handler {
+	housekeepingHandler := &housekeepingHandler{
 		Context: ctx,
 	}
 
 	mhandler := handlers.MethodHandler{}
 
 	if !ctx.readOnly {
-		mhandler["DELETE"] = http.HandlerFunc(recycleHandler.Recycle)
+		mhandler["DELETE"] = http.HandlerFunc(housekeepingHandler.Recycle)
 	}
 
 	return mhandler
 }
 
 // blobHandler serves http blob requests.
-type recycleHandler struct {
+type housekeepingHandler struct {
 	*Context
 
 	Digest digest.Digest

--- a/registry/handlers/recycle.go
+++ b/registry/handlers/recycle.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution/context"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+)
+
+// blobDispatcher uses the request context to build a blobHandler.
+func recycleDispatcher(ctx *Context, r *http.Request) http.Handler {
+	recycleHandler := &recycleHandler{
+		Context: ctx,
+	}
+
+	mhandler := handlers.MethodHandler{}
+
+	if !ctx.readOnly {
+		mhandler["DELETE"] = http.HandlerFunc(recycleHandler.Recycle)
+	}
+
+	return mhandler
+}
+
+// blobHandler serves http blob requests.
+type recycleHandler struct {
+	*Context
+
+	Digest digest.Digest
+}
+
+// GetBlob fetches the binary data from backend storage returns it in the
+// response.
+func (bh *blobHandler) Recycle(w http.ResponseWriter, r *http.Request) {
+	context.GetLogger(bh).Debug("Recycle")
+
+	// blobs := bh.Repository.Blobs(bh)
+	// desc, err := blobs.Stat(bh, bh.Digest)
+	// if err != nil {
+	// 	if err == distribution.ErrBlobUnknown {
+	// 		bh.Errors = append(bh.Errors, v2.ErrorCodeBlobUnknown.WithDetail(bh.Digest))
+	// 	} else {
+	// 		bh.Errors = append(bh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+	// 	}
+	// 	return
+	// }
+
+	// if err := blobs.ServeBlob(bh, w, r, desc.Digest); err != nil {
+	// 	context.GetLogger(bh).Debugf("unexpected error getting blob HTTP handler: %v", err)
+	// 	bh.Errors = append(bh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+	// 	return
+	// }
+
+	w.Header().Set("Content-Length", "0")
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -25,6 +25,10 @@ type proxyManifestStore struct {
 
 var _ distribution.ManifestService = &proxyManifestStore{}
 
+func (pms proxyManifestStore) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	return nil
+}
+
 func (pms proxyManifestStore) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	exists, err := pms.localManifests.Exists(ctx, dgst)
 	if err != nil {

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -57,7 +57,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 			return err
 		}
 
-		err = v.RemoveBlob(r.Digest().String())
+		err = v.RemoveBlob(r.Digest())
 		if err != nil {
 			return err
 		}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -246,6 +246,10 @@ type proxiedRepository struct {
 	tags      distribution.TagService
 }
 
+func (pr *proxiedRepository) RepositoryBlobsEnumerator(ctx context.Context) distribution.BlobEnumerator {
+	return nil
+}
+
 func (pr *proxiedRepository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
 	return pr.manifests, nil
 }

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -237,7 +237,7 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 		}
 
 		descriptor, err := bs.stat(ctx, dgst, path)
-		if err == distribution.ErrBlobUnknown {
+		if err == nil {
 			return descriptor, err
 		}
 	}
@@ -253,11 +253,9 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 		}
 
 		descriptor, err := bs.stat(ctx, dgst, path)
-		if err == distribution.ErrBlobUnknown {
+		if err == nil {
 			return descriptor, err
 		}
-
-		return bs.stat(ctx, dgst, path)
 	}
 
 	return distribution.Descriptor{}, distribution.ErrBlobUnknown

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -24,6 +24,7 @@ type blobStore struct {
 }
 
 var _ distribution.BlobProvider = &blobStore{}
+var _ distribution.BlobEnumerator = &blobStore{}
 
 // Get implements the BlobReadService.Get call.
 func (bs *blobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -87,6 +87,14 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (distr
 	}, bs.driver.PutContent(ctx, bp, p)
 }
 
+func (bs *blobStore) IsScopped() bool {
+	if bs.options.repositoryBlobStoreEnabled && bs.repositoryScope != "" {
+		return true
+	}
+
+	return false
+}
+
 func (bs *blobStore) Enumerate(ctx context.Context, ingester func(dgst digest.Digest) error) error {
 	specPath, err := bs.rootPath()
 	if err != nil {

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -73,6 +73,12 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
+	// set store path
+	canonical.Location, err = bw.storePath(desc.Digest)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+
 	if err := bw.moveBlob(ctx, canonical); err != nil {
 		return distribution.Descriptor{}, err
 	}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -143,7 +143,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		if opts.DryRun {
 			continue
 		}
-		err = vacuum.RemoveBlob(string(dgst))
+		err = vacuum.RemoveBlob(dgst)
 		if err != nil {
 			return fmt.Errorf("failed to delete blob %s: %v", dgst, err)
 		}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -45,6 +45,7 @@ type linkedBlobStore struct {
 }
 
 var _ distribution.BlobStore = &linkedBlobStore{}
+var _ distribution.BlobEnumerator = &linkedBlobStore{}
 
 func (lbs *linkedBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	return lbs.blobAccessController.Stat(ctx, dgst)

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -409,3 +409,11 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		resumableDigestEnabled: repo.resumableDigestEnabled,
 	}
 }
+
+func (repo *repository) RepositoryBlobsEnumerator(ctx context.Context) distribution.BlobEnumerator {
+	if repo.options.repositoryBlobStoreEnabled {
+		return repo.scopedBlobStore()
+	}
+
+	return nil
+}

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -28,14 +28,14 @@ type Vacuum struct {
 	ctx    context.Context
 }
 
-// RemoveLocalBlob removes a blob from the filesystem
-func (v Vacuum) RemoveLocalBlob(name string, dgst string) error {
+// RemoveRepositoryBlob removes a blob from the filesystem
+func (v Vacuum) RemoveRepositoryBlob(repositoryScope string, dgst string) error {
 	d, err := digest.Parse(dgst)
 	if err != nil {
 		return err
 	}
 
-	blobPath, err := pathFor(repositoryBlobPathSpec{name: name, digest: d})
+	blobPath, err := pathFor(repositoryBlobPathSpec{name: repositoryScope, digest: d})
 	if err != nil {
 		return err
 	}

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -29,13 +29,8 @@ type Vacuum struct {
 }
 
 // RemoveRepositoryBlob removes a blob from the filesystem
-func (v Vacuum) RemoveRepositoryBlob(repositoryScope string, dgst string) error {
-	d, err := digest.Parse(dgst)
-	if err != nil {
-		return err
-	}
-
-	blobPath, err := pathFor(repositoryBlobPathSpec{name: repositoryScope, digest: d})
+func (v Vacuum) RemoveRepositoryBlob(repositoryScope string, dgst digest.Digest) error {
+	blobPath, err := pathFor(repositoryBlobPathSpec{name: repositoryScope, digest: dgst})
 	if err != nil {
 		return err
 	}
@@ -51,13 +46,8 @@ func (v Vacuum) RemoveRepositoryBlob(repositoryScope string, dgst string) error 
 }
 
 // RemoveBlob removes a blob from the filesystem
-func (v Vacuum) RemoveBlob(dgst string) error {
-	d, err := digest.Parse(dgst)
-	if err != nil {
-		return err
-	}
-
-	blobPath, err := pathFor(blobPathSpec{digest: d})
+func (v Vacuum) RemoveBlob(dgst digest.Digest) error {
+	blobPath, err := pathFor(blobPathSpec{digest: dgst})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This implements API call for performing housekeeping operation:

* remove all unreferenced manifests,
* remove all unreferenced per-repository blobs.

This is still unsafe to run online, but something to be fixed later, by:

1. keeping information about recently accessed blobs,
2. using Redis to share that repository is temporarily read-only (since this operation would be like 3-5s to execute it should be possible to do and Docker should retry all).